### PR TITLE
Adding sequence to itself to account for circular sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The client here will eventually be released as "freegenes"
 and the versions here will coincide with these releases.
 
 ## [master](https://github.com/vsoch/freegenes-python/tree/master)
+ - CompositeParts can be circular [#9](https://github.com/vsoch/freegenes-python/issues/9) (0.0.14)
  - CompositePart endpoint (0.0.13)
  - Adding plate-map parsing to Twist (0.0.12)
  - Twist API client endpoints (0.0.11)

--- a/docs/_docs/getting-started/python-client.md
+++ b/docs/_docs/getting-started/python-client.md
@@ -172,6 +172,13 @@ and then from those results we find a "best answer" with a scheduling algorithm:
  3. For each new element, we check it against a list of selected_sequence items (which starts empty) to look for any overlap.
  4. If there isn't overlap, we add to selected sequences.
 
+We assume that the sequence provided is circular, but if it's not, you should set circular
+to False:
+
+```python
+> composite_part = client.create_composite_part(name=name, sequence=sequence, circular=False)
+```
+
 The final result will include an ordered list of the longest parts. If there are other
 combinations, the client could remove the first match (the longest) and repeat the algorithm again -
 however in practice the first result is the "right answer" and subsequent results turn out to 

--- a/freegenes/main/__init__.py
+++ b/freegenes/main/__init__.py
@@ -215,6 +215,7 @@ class Client(object):
 
     def create_composite_part(self, name, 
                                     sequence,
+                                    circular=True,
                                     part_ids=None,
                                     description=None,
                                     direction_string=None,
@@ -229,6 +230,7 @@ class Client(object):
            ==========
            name: a name for the composite part (required)
            sequence: the new sequence (required)
+           circular: is the sequence circular? (default True)
            part_ids: a list of one or more part ids (optional)
            description: a string description (optional)
            composite_id: a composite id (optional) (like gene_id for a part)
@@ -238,7 +240,7 @@ class Client(object):
         if not part_ids:
 
             # [(uuid, direction, start, end),
-            selected_parts = self._derive_parts(sequence)
+            selected_parts = self._derive_parts(sequence, circular)
             part_ids = [x[0] for x in selected_parts]
             direction_string = "".join([x[1] for x in selected_parts])
 

--- a/freegenes/main/helpers.py
+++ b/freegenes/main/helpers.py
@@ -32,6 +32,9 @@ def derive_parts(self, sequence):
     '''
     self._cache_parts()
 
+    # To account for circular sequences
+    sequence = sequence + sequence
+
     # Parts found to match
     coords = []
 

--- a/freegenes/main/helpers.py
+++ b/freegenes/main/helpers.py
@@ -14,11 +14,12 @@ import requests
 import os
 import re
 
-def derive_parts(self, sequence):
+def derive_parts(self, sequence, circular=True):
     '''based on a sequence, search all freegenes parts for the sequence,
        forward and backwards. This is done by the client (and not on the
        server) as to not tax the server. We cache the parts request to
-       not make the same one over and over.
+       not make the same one over and over. If the sequence is circular,
+       we add it to itself, otherwise not.
 
        Algorithm:
        =========
@@ -33,7 +34,8 @@ def derive_parts(self, sequence):
     self._cache_parts()
 
     # To account for circular sequences
-    sequence = sequence + sequence
+    if circular:
+        sequence = sequence + sequence
 
     # Parts found to match
     coords = []

--- a/freegenes/version.py
+++ b/freegenes/version.py
@@ -5,7 +5,7 @@
 # Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-__version__ = "0.0.13"
+__version__ = "0.0.14"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'freegenes'


### PR DESCRIPTION
This will close #9 - it's a fairly simple modification to allow for the possibility of a circular sequence, or a part being present in the circular version of the sequence. It's probably easiest to provide an example:

Let's say that we are searching for "AAAA" (a part) in our composite part. If the composite part looks like this:

```
AAGGGGAA
```
We don't find it. But if we repeat the thing you're searching in (the composite part) twice

```
AAGGGGAA -> AAGGGGAA + AAGGGGAA = AAGGGGAAAAGGGGAA
```

Then we would easily find "AAAA"

```
AAGGGGAAAAGGGGAA
```

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>